### PR TITLE
batch log messages and shorten field names

### DIFF
--- a/lib/fluent/plugin/out_vmware_loginsight.rb
+++ b/lib/fluent/plugin/out_vmware_loginsight.rb
@@ -1,11 +1,11 @@
 # Fluentd plugin for VMware Log Insight
-# 
-# Copyright 2018 VMware, Inc. All Rights Reserved. 
-# 
-# This product is licensed to you under the MIT license (the "License").  You may not use this product except in compliance with the MIT License.  
-# 
-# This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file. 
-# 
+#
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the MIT license (the "License").  You may not use this product except in compliance with the MIT License.
+#
+# This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+#
 # SPDX-License-Identifier: MIT
 
 
@@ -18,9 +18,9 @@ module Fluent
   module Plugin
     class Fluent::VmwareLoginsightOutput < Fluent::Output
       class ConnectionFailure < StandardError; end
-    
+
       Fluent::Plugin.register_output('vmware_loginsight', self)
-    
+
       ### Connection Params ###
       config_param :scheme, :string, :default => 'http'
       # Loginsight Host ex. localhost
@@ -38,11 +38,11 @@ module Fluent
       config_param :password, :string, :default => nil, :secret => true
       # Authentication nil | 'basic'
       config_param :authentication, :string, :default => nil
-    
+
       # Set Net::HTTP.verify_mode to `OpenSSL::SSL::VERIFY_NONE`
       config_param :ssl_verify, :bool, :default => true
       config_param :ca_file, :string, :default => nil
-    
+
       ### API Params ###
       # HTTP method
       # post | put
@@ -51,7 +51,8 @@ module Fluent
       config_param :serializer, :string, :default => :json
       config_param :request_retries, :integer, :default => 3
       config_param :request_timeout, :time, :default => 5
-    
+      config_param :max_batch_size, :integer, :default => 512000
+
       # Simple rate limiting: ignore any records within `rate_limit_msec`
       # since the last one.
       config_param :rate_limit_msec, :integer, :default => 0
@@ -65,15 +66,15 @@ module Fluent
       config_param :flatten_hashes, :bool, :default => true
       # Seperator to use for joining flattened keys
       config_param :flatten_hashes_separator, :string, :default => "__"
-    
-    
+
+
       def initialize
         super
       end
-    
+
       def configure(conf)
         super
-    
+
         @ssl_verify_mode = @ssl_verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
         @auth = case @authentication
                 when 'basic'
@@ -81,92 +82,108 @@ module Fluent
                 else
                   :none
                 end
-    
+
         @last_request_time = nil
       end
-    
+
       def start
         super
       end
-    
+
       def shutdown
         super
       end
-    
+
       def format_url()
         url = "#{@scheme}://#{host}:#{port}/#{path}/#{agent_id}"
         url
       end
-    
+
       def set_header(req)
         if @serializer == 'json'
           set_json_header(req)
         end
         req
       end
-    
+
       def set_json_header(req)
         req['Content-Type'] = 'application/json'
         req
       end
-    
-      def set_body(req, tag, time, record)
-        if @serializer == 'json'
-          set_json_body(req, tag, time, record)
-        end
-        req
+
+      def shorten_key(key)
+        # LI doesn't allow some characters in field 'name'
+        # like '/', '-', '\', '.', etc. so replace them with '_'
+        key = key.gsub(/[\/\.\-\\]/,'_').downcase
+        # remove double underscores
+        key = key.gsub(/__/,'_')
+        # shorten field names
+        key = key.gsub(/kubernetes_/,'')
+        key = key.gsub(/labels_/,'')
+        key = key.gsub(/_name/,'')
+        key = key.gsub(/_hash/,'')
+        key = key.gsub(/container_/,'')
+        key
       end
-    
-      def set_json_body(req, tag, time, record)
-        req.body = create_loginsight_events(tag, time, record).to_json
-      end
-    
-      def create_loginsight_events(tag, time, record)
+
+      def create_loginsight_event(tag, time, record)
         flattened_records = {}
         if @flatten_hashes
           flattened_records = flatten_record(record, [])
         end
         flattened_records[@tag_key] = tag if @include_tag_key
         fields = []
+        keys = []
         log = ''
         flattened_records.each do |key, value|
-          next if value.nil?
-          # LI doesn't allow some characters in field 'name'
-          # like '/', '-', '\', '.', etc. so replace them with '__'
-          key = key.gsub(/[\/\.\-\\]/,'__').downcase
-          # LI needs to have field keys/values in utf-8 format
-          key.force_encoding("utf-8")
-          value.force_encoding("utf-8")
+          begin
+            next if value.nil?
+            # LI doesn't support duplicate fields, make unique names by appending underscore
+            key = shorten_key(key)
+            while keys.include?(key)
+              key = key + '_'
+            end
+            keys.push(key)
+            key.force_encoding("utf-8")
+            # convert value to string if needed
+            begin
+              value = value.to_s if not value.instance_of?(String)
+              value.force_encoding("utf-8")
+            rescue Exception=>e
+              $log.warn "force_encoding exception: " "#{e.class}, '#{e.message}', " \
+                        "\n Request: #{key} #{record.to_json[1..1024]}"
+              value = "Exception during conversion: #{e.message}"
+            end
+          end
           if ['log', 'message', 'msg'].include?(key)
             if log != "#{value}"
-              log += " #{value}"
+              if log.empty?
+                log = "#{value}"
+              else
+                log += " #{value}"
+              end
             end
           else
             # If there is time information available, update time for LI. LI ignores
             # time if it is out of the error/adjusment window of 10 mins. in such
-            # cases we would still like to preserve time info, so add it as event
-            # TODO Ignore the below block for now. Handle the case for time being in 
-            #      different formats than milliseconds
-            #if ['time', '_source_realtime_timestamp'].include?(key)
-            #  time = value
-            #end
+            # cases we would still like to preserve time info, so add it as event.
+            if ['time', '_source_realtime_timestamp'].include?(key)
+              time = value
+            end
             fields << {"name" => key, "content" => value}
           end
         end
-        events = {
-          "events" => [{
-            "fields" => fields,
-            "text" => log,
-            "timestamp" => time
-          }]
+        event = {
+          "fields" => fields,
+          "text" => log.gsub(/^$\n/, ''),
+          "timestamp" => time * 1000
         }
-        events
+        event
       end
-    
-    
+
       def flatten_record(record, prefix=[])
         ret = {}
-    
+
         case record
           when Hash
             record.each { |key, value|
@@ -180,7 +197,7 @@ module Fluent
         end
         ret
       end
-    
+
       def create_request(tag, time, record)
         url = format_url()
         uri = URI.parse(url)
@@ -189,15 +206,15 @@ module Fluent
         set_header(req)
         return req, uri
       end
-    
-    
+
+
       def send_request(req, uri)
         is_rate_limited = (@rate_limit_msec != 0 and not @last_request_time.nil?)
         if is_rate_limited and ((Time.now.to_f - @last_request_time) * 1000.0 < @rate_limit_msec)
           $log.info('Dropped request due to rate limiting')
           return
         end
-    
+
         if @auth and @auth == 'basic'
           req.basic_auth(@username, @password)
         end
@@ -205,7 +222,7 @@ module Fluent
           retries ||= 2
           response = nil
           @last_request_time = Time.now.to_f
-    
+
           http_conn = Net::HTTP.new(uri.host, uri.port)
           # For debugging, set this
           #http_conn.set_debug_output($stdout)
@@ -214,7 +231,7 @@ module Fluent
             http_conn.ca_file = @ca_file
           end
           http_conn.verify_mode = @ssl_verify_mode
-    
+
           response = http_conn.start do |http|
             http.read_timeout = @request_timeout
             http.request(req)
@@ -224,8 +241,8 @@ module Fluent
           # Be careful while turning on below log, if LI instance can't be reached and you're sending
           # log-container logs to LI as well, you may end up in a cycle.
           # TODO handle the cyclic case at plugin level if possible.
-          #$log.warn "Net::HTTP.#{req.method.capitalize} raises exception: " \
-          #   "#{e.class}, '#{e.message}', \n Request: #{req.body}"
+          # $log.warn "Net::HTTP.#{req.method.capitalize} raises exception: " \
+          #   "#{e.class}, '#{e.message}', \n Request: #{req.body[1..1024]}"
           retry unless (retries -= 1).zero?
           raise e if @raise_on_error
         else
@@ -238,21 +255,49 @@ module Fluent
                                "Response = nil"
                             end
               # ditto cyclic warning
-              #$log.warn "Failed to #{req.method} #{uri}\n(#{res_summary})\n" \
-              #   "Request Body: #{req.body}"
+              # $log.warn "Failed to #{req.method} #{uri}\n(#{res_summary})\n" \
+              #   "Request Size: #{req.body.size} Request Body: #{req.body[1..1024]}"
            end #end unless
         end # end begin
       end # end send_request
-    
-      def handle_record(tag, time, record)
-        req, uri = create_request(tag, time, record)
+
+      def send_events(uri, events)
+        req = Net::HTTP.const_get(@http_method.to_s.capitalize).new(uri.path)
+        event_req = {
+          "events" => events
+        }
+        req.body = event_req.to_json
+        set_header(req)
         send_request(req, uri)
       end
-    
-      def emit(tag, es, chain)
+
+      def handle_records(tag, es)
+        url = format_url()
+        uri = URI.parse(url)
+        events = []
+        count = 0
         es.each do |time, record|
-          handle_record(tag, time, record)
+          new_event = create_loginsight_event(tag, time, record)
+          new_event_size = new_event.to_json.size
+          if new_event_size > @max_batch_size
+              $log.warn "dropping event larger than max_batch_size: #{new_event.to_json[1..1024]}"
+          else
+            if (count + new_event_size) > @max_batch_size
+              send_events(uri, events)
+              events = []
+              count = 0
+            end
+            count += new_event_size
+            events << new_event
+          end
         end
+        if count > 0
+          send_events(uri, events)
+        end
+      end
+
+      def emit(tag, es, chain)
+        handle_records(tag, es)
         chain.next
       end
     end


### PR DESCRIPTION
send log messages in batches, add max_batch_size parameter
shorten field names by removing kubernetes_ and _name prefix/suffix
convert time to milliseconds
exception handling for field names and numeric values