### PR TITLE
Fix handling of LI fields with the words 'name' and 'namespaces' in them. Also, bump the gemspec version.

### DIFF
--- a/fluent-plugin-vmware-loginsight.gemspec
+++ b/fluent-plugin-vmware-loginsight.gemspec
@@ -14,7 +14,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name    = "fluent-plugin-vmware-loginsight"
-  spec.version = "0.1.2"
+  spec.version = "0.1.3"
   spec.authors = ["Vishal Mohite"]
   spec.email   = ["vmohite@vmware.com"]
 

--- a/lib/fluent/plugin/out_vmware_loginsight.rb
+++ b/lib/fluent/plugin/out_vmware_loginsight.rb
@@ -119,11 +119,11 @@ module Fluent
         key = key.gsub(/__/,'_')
         # shorten field names
         key = key.gsub(/kubernetes_/,'k8s_')
+        key = key.gsub(/namespace/,'ns')
         key = key.gsub(/labels_/,'')
         key = key.gsub(/_name/,'')
         key = key.gsub(/_hash/,'')
         key = key.gsub(/container_/,'')
-        key = key.gsub(/namespace/,'ns')
         key
       end
 


### PR DESCRIPTION
Fix handling of LI fields with the words 'name' and 'namespaces' in them. Also, bump the gemspec version.