### PR TITLE
Fix for basic auth check

### DIFF
--- a/lib/fluent/plugin/out_vmware_loginsight.rb
+++ b/lib/fluent/plugin/out_vmware_loginsight.rb
@@ -230,7 +230,7 @@ module Fluent
           return
         end
 
-        if @auth and @auth == 'basic'
+        if @auth and @auth.to_s.eql? "basic"
           req.basic_auth(@username, @password)
         end
         begin


### PR DESCRIPTION
@auth is a Symbol, and doesn't compare directly to a string, thereby never satisfying the condition.