### PR TITLE
Also filter out @ from field names

### DIFF
--- a/lib/fluent/plugin/out_vmware_loginsight.rb
+++ b/lib/fluent/plugin/out_vmware_loginsight.rb
@@ -118,7 +118,7 @@ module Fluent
       def shorten_key(key)
         # LI doesn't allow some characters in field 'name'
         # like '/', '-', '\', '.', etc. so replace them with @flatten_hashes_separator
-        key = key.gsub(/[\/\.\-\\]/,@flatten_hashes_separator).downcase
+        key = key.gsub(/[\/\.\-\\\@]/,@flatten_hashes_separator).downcase
         # shorten field names
         key = key.gsub(/kubernetes_/,'k8s_')
         key = key.gsub(/namespace/,'ns')


### PR DESCRIPTION
We ran into a situation where fluentd had a field with an @ in it. This was causing 400 errors from log insight like so:

Response Code: 400
Response Message:
Response Body: {"errorMessage":"Invalid message field name"})

This resolves that issue by adding @ to the list of special characters that get substituted in the field name.