### PR TITLE
Also filter out @ from field names

### DIFF
--- a/lib/fluent/plugin/out_vmware_loginsight.rb
+++ b/lib/fluent/plugin/out_vmware_loginsight.rb
@@ -118,7 +118,7 @@ module Fluent
       def shorten_key(key)
         # LI doesn't allow some characters in field 'name'
         # like '/', '-', '\', '.', etc. so replace them with @flatten_hashes_separator
-        key = key.gsub(/[\/\.\-\\]/,@flatten_hashes_separator).downcase
+        key = key.gsub(/[\/\.\-\\\@]/,@flatten_hashes_separator).downcase
         # shorten field names
         key = key.gsub(/kubernetes_/,'k8s_')
         key = key.gsub(/namespace/,'ns')


### PR DESCRIPTION
We had a situation where a fluentd field name had a @ in it. This was causing 400 errors like so:

Response Code: 400
Response Message:
Response Body: {"errorMessage":"Invalid message field name"})

This change resolves that issue by adding @ to the list of special characters which get substituted before being sent over.