### PR TITLE
shorten_key default hash keys convert to string

### DIFF
--- a/lib/fluent/plugin/out_vmware_loginsight.rb
+++ b/lib/fluent/plugin/out_vmware_loginsight.rb
@@ -144,7 +144,7 @@ module Fluent
         key = key.gsub(/[\/\.\-\\]/,@flatten_hashes_separator).downcase
         # shorten field names using provided shorten_keys parameters
         @shorten_keys.each do | match, replace |
-            key = key.gsub(match,replace)
+            key = key.gsub(match.to_s,replace)
         end
         key
       end


### PR DESCRIPTION
the default key type of the hash is Symbol, needs to be converted
to a String before calling gsub

Signed-off-by: Chris Todd <toddc@vmware.com>