### PR TITLE
Enabled buffering in plugin which allows send log events in chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ $ bundle
   enable_stat_watcher false
   refresh_interval 5
   tag kubernetes.*
+  # Open below line if you need have filename as tag field (now without prefix kubernetes.)
+  # path_key tag
   <parse>
     @type json
     time_key time
@@ -136,12 +138,6 @@ rate_limit_msec, :integer, :default => 0
 
 # Raise errors that were rescued during HTTP requests?
 raise_on_error, :bool, :default => false :: Valid Value: true | false 
-
-# Include tag key as log event?
-include_tag_key, :bool, :default => true :: Valid Value: true | false 
-
-# Metadata key that identifies Fluentd tags
-tag_key, :string, :default => 'tag'
 
 # Keys from log event whose values should be added as log message/text to loginsight.
 # These key/value pairs won't expanded/flattened and won't be added as metadata/fields.


### PR DESCRIPTION
Enabled buffering in plugin which allows send chunk of logs into LI using CFAPI protocol. Prior this change when fluend call method of our plugin `process()` data contains only one log event, and each time we send only one event. Sending process consumes huge time and not effective when plugin sends only one log event. In result we side effect when logs don't get ingested long-long time. With this change we enabled buffering. Which enables fluentd to send bunch of logs which get processed in plugin and plugin send (based my investigations) around 300 log events at once.