### PR TITLE
Install systemd package for photon base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,40 @@
 # Fluentd is configured with the default configuration that gets produced by the `fluentd --setup` command. For an example of
 # a configuration that uses the fluent-plugin-vmware-loginsight plugin check fluent.conf under the examples dir:
 # https://github.com/vmware/fluent-plugin-vmware-loginsight/blob/master/examples/fluent.conf
-FROM photon:4.0-20230227
+FROM photon:4.0-20230610
 
 USER root
 
-RUN buildDeps="\
-    binutils linux-api-headers glibc-devel \
-    make gcc gmp-devel libffi-devel \
-    tar bzip2 sed gawk build-essential" \
+ENV  BUILDDEPS="\
+    gmp-devel \
+    libffi-devel \
+    bzip2 \
+    shadow \
+    wget \
+    which \
+    vim \
+    git \
+    less \
+    tar \
+    gzip \
+    sed \
+    gawk \
+    gcc \
+    build-essential \
+    zlib-devel \
+    libedit \
+    libedit-devel \
+    gdbm \
+    gdbm-devel \
+    openssl-devel \
+    linux-api-headers"
+
+RUN \
     #
     # Distro sync and install build dependencies
-    && tdnf distro-sync --refresh -y \
+    tdnf distro-sync --refresh -y \
     && tdnf remove -y toybox \
-    && tdnf install -y $buildDeps ruby \
+    && tdnf install -y $BUILDDEPS systemd ruby \
     #
     # These are not required but are used if available
     && gem install oj -v 3.3.10 \
@@ -45,17 +66,21 @@ RUN buildDeps="\
     && gem install --norc --no-document fluent-plugin-kubernetes_metadata_filter \
     #
     # Install Log Insight plugin
-    && gem install --norc --no-document -v 1.4.0 fluent-plugin-vmware-loginsight \
+    && gem install --norc --no-document -v 1.4.1 fluent-plugin-vmware-loginsight \
     #
     # Install jemalloc 5.3.0
     && curl -L --output /tmp/jemalloc-5.3.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 \
     && tar -C /tmp/ -xjvf /tmp/jemalloc-5.3.0.tar.bz2 \
     && cd /tmp/jemalloc-5.3.0 \
-    && ./configure && make \
-    && mv lib/libjemalloc.so.2 /usr/lib \
+    # Don't use MADV_FREE to reduce memory usage and improve stability
+    # https://github.com/fluent/fluentd-docker-image/pull/350
+    && (echo "je_cv_madv_free=no" > config.cache) && ./configure --disable-cxx --disable-prof-libgcc && make \
+    && mv -v lib/libjemalloc.so* /usr/lib \
     && cd / \
-    && rm -rf /tmp/jemalloc-5.3.0* \
-    && tdnf remove -y $buildDeps \
+    #
+    # Remove all fluentd build deps and non needit configs
+    && rm -rf /tmp/jemalloc-5.3.0* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/3.*/gems/fluentd-*/test \
+    && tdnf remove -y $BUILDDEPS \
     && tdnf clean all \
     && gem sources --clear-all \
     && gem cleanup
@@ -63,7 +88,7 @@ RUN buildDeps="\
 # Create default fluent.conf
 RUN fluentd --setup /etc/fluentd
 
-# Make sure fluentd picks jemalloc
+# Make sure fluentd picks jemalloc 5.3.0 lib as default
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 
 # Standard fluentd ports


### PR DESCRIPTION
Fixes photon base image issue for fluentd-systemd plugin.
Fixes https://github.com/vmware/fluent-plugin-vmware-loginsight/issues/30

Others:
- Updated photon base image latest patch 
- Added a few more packages to builddeps
- Updated jemalloc compilation issue