### PR TITLE
correctly handle fractions of seconds in timestamps

### DIFF
--- a/lib/fluent/plugin/out_vmware_loginsight.rb
+++ b/lib/fluent/plugin/out_vmware_loginsight.rb
@@ -207,7 +207,7 @@ module Fluent::Plugin
       event = {
         "fields" => fields,
         "text" => log.gsub(/^$\n/, ''),
-        "timestamp" => time * 1000
+        "timestamp" => (time.to_f * 1000).floor()
       }
       event
     end


### PR DESCRIPTION
Fixes #32 in which timestamps sent to log insight always get rounded down to the closest full second, losing the millisecond information.  A timestamp like this "2021-08-13T14:41:21.898738172+00:00" gets converted to a Unix timestamp of 1628865681000. The correct value would be 1628865681898.

This patch keeps the milliseconds information by converting the time variable (a Fluent EventTime object) to a floating point variable before it is multiplied by 1000 so that the millisecond information is not lost. It then rounds it down to a full long integer to get a valid Unix timestamp.